### PR TITLE
Update HF Audio Transformer Course link and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Audio Transformers Course
 
-This repo contains the content that's used to create [Hugging Face's Audio Transformers Course](https://huggingface.co/audio-course). 
-The course teaches you about applying Transformers to various tasks in audio and speech processing.It's completely free and open-source!
+This repo contains the content that's used to create [Hugging Face's Audio Transformers Course](https://huggingface.co/learn/audio-course). 
+The course teaches you about applying Transformers to various tasks in audio and speech processing. It's completely free and open-source!
 
 
 ### Translating the course into your language
@@ -84,7 +84,7 @@ This will build and render the course on [http://localhost:3000/](http://localho
 
 **🚀 Submit a pull request**
 
-If the translations look good locally, the final step is to prepare the content for a pull request. Here, the first think to check is that the files are formatted correctly. For that you can run:
+If the translations look good locally, the final step is to prepare the content for a pull request. Here, the first thing to check is that the files are formatted correctly. For that you can run:
 
 ```
 pip install -r requirements.txt


### PR DESCRIPTION
Fixed dead link for the course ReadMe file and typo:  https://huggingface.co/learn/audio-course/
@MKhalusova 