### PR TITLE
typo correction in asr_pipeline.mdx (Unit 2: Automatic speech recognition with a pipeline)

### DIFF
--- a/chapters/en/chapter2/asr_pipeline.mdx
+++ b/chapters/en/chapter2/asr_pipeline.mdx
@@ -7,7 +7,7 @@ for virtual assistants like Siri and Alexa.
 In this section, we'll use the `automatic-speech-recognition` pipeline to transcribe an audio recording of a person
 asking a question about paying a bill using the same MINDS-14 dataset as before.
 
-To get started, load the datas  et and upsample it to 16kHz as described in [Audio classification with a pipeline](introduction.mdx),
+To get started, load the dataset and upsample it to 16kHz as described in [Audio classification with a pipeline](introduction.mdx),
 if you haven't done that yet.
 
 To transcribe an audio recording, we can use the `automatic-speech-recognition` pipeline from 🤗 Transformers. Let's


### PR DESCRIPTION
I was going through [Automatic speech recognition with a file](https://huggingface.co/learn/audio-course/chapter2/asr_pipeline) section of Unit 2.

This is contained in the file in the repo: **chapters/en/chapter2/asr_pipeline.mdx**.

I saw the spelling `datas  et` appear which should instead be `dataset`. I corrected that.

Changed:
```-
datas  et
```
to:
```+
dataset
```

