### PR TITLE
accessing the audio array instead of the file (Update classification_models.mdx)

### DIFF
--- a/chapters/en/chapter4/classification_models.mdx
+++ b/chapters/en/chapter4/classification_models.mdx
@@ -121,7 +121,7 @@ checkpoint fine-tuned on the Speech Commands dataset, under the namespace [`"MIT
 classifier = pipeline(
     "audio-classification", model="MIT/ast-finetuned-speech-commands-v2"
 )
-classifier(sample["audio"])
+classifier(sample["audio"]["array"])
 ```
 **Output:**
 ```


### PR DESCRIPTION
The code suggested in [Speech Commands section](https://huggingface.co/learn/audio-course/chapter4/classification_models?fw=pt#speech-commands) of Unit 4:  Pre-trained models and datasets for audio classification, the code written is:

```python3
classifier = pipeline(
    "audio-classification", model="MIT/ast-finetuned-speech-commands-v2"
)
classifier(sample["audio"])
```

But `sample["audio"]` does not give access to the value that is an ndarray, and hence this gives rise to an error, described in #55.

The code instead should be:

```python3
classifier = pipeline(
    "audio-classification", model="MIT/ast-finetuned-speech-commands-v2"
)
classifier(sample["audio"]["array"])
```

`sample` looks like this:

```out
{'file': 'backward/0d82fd99_nohash_2.wav',
 'audio': {'path': 'backward/0d82fd99_nohash_2.wav',
  'array': array([-9.15527344e-05,  6.10351562e-05,  6.10351562e-05, ...,
          2.68859863e-02,  1.46179199e-02,  1.67846680e-03]),
  'sampling_rate': 16000},
 'label': 30,
 'is_unknown': True,
 'speaker_id': '0d82fd99',
 'utterance_id': 2}
```

And `classifier` requires an ndarray. So, to access the audio ndarray, `sample["audio"]["array"]` is the correct keyword instead of `sample["audio"]` and this expectedly gives rise to a ValueError from the `classifier` function.

This PR solves this issue. Described in #55.

The correct code should be:

```+
classifier(sample["audio"]["array"])
```
instead of:
```-
classifier(sample["audio"])
```

This change leads to the expected output of:

```out
[{'score': 0.9999892711639404, 'label': 'backward'},
 {'score': 1.7504938796264469e-06, 'label': 'happy'},
 {'score': 6.703033363919531e-07, 'label': 'follow'},
 {'score': 5.805895852972753e-07, 'label': 'stop'},
 {'score': 5.614552378574444e-07, 'label': 'up'}]
```

I have run this, and attaching screenshots from Colab in a following comment.