### PR TITLE
[U5 fine-tuning] Pin num_proc to 1 in map

### DIFF
--- a/chapters/en/chapter5/fine-tuning.mdx
+++ b/chapters/en/chapter5/fine-tuning.mdx
@@ -204,7 +204,7 @@ remove the columns from the raw training data (the audio and text), leaving just
 
 ```python
 common_voice = common_voice.map(
-    prepare_dataset, remove_columns=common_voice.column_names["train"], num_proc=2
+    prepare_dataset, remove_columns=common_voice.column_names["train"], num_proc=1
 )
 ```
 


### PR DESCRIPTION
Pins the number of pre-processor workers in datasets `.map` to 1 so that we retain the dataset config/name information. We can un-pin this once https://github.com/huggingface/datasets/issues/5967 is resolved