### PR TITLE
This is to avoid this code breaking against forthcoming version 1.0 o…

### DIFF
--- a/chapters/en/chapter1/preprocessing.mdx
+++ b/chapters/en/chapter1/preprocessing.mdx
@@ -95,7 +95,7 @@ dataset. However, we can create one, filter based on the values in that column, 
 
 ```py
 # use librosa to get example's duration from the audio file
-new_column = [librosa.get_duration(filename=x) for x in minds["path"]]
+new_column = [librosa.get_duration(path=x) for x in minds["path"]]
 minds = minds.add_column("duration", new_column)
 
 # use 🤗 Datasets' `filter` method to apply the filtering function


### PR DESCRIPTION
This is to avoid this code breaking against forthcoming version 1.0 of librosa. Old code caused warning message: FutureWarning: get_duration() keyword argument 'filename' has been renamed to 'path' in version 0.10.0.

    This alias will be removed in version 1.0.
  new_column = [librosa.get_duration(filename=x) for x in minds["path"]]
it should be: new_column = [librosa.get_duration(path=x) for x in minds["path"]]