### PR TITLE
Fix broken links in Chapter 5

### DIFF
--- a/chapters/en/chapter5/asr_models.mdx
+++ b/chapters/en/chapter5/asr_models.mdx
@@ -1,6 +1,6 @@
 # Pre-trained models for automatic speech recognition
 
-In this section, we'll cover how to use the `pipeline()` to leverage pre-trained models for speech recognition. In [Unit 2](../chapter2/asr_pipeline.mdx),
+In this section, we'll cover how to use the `pipeline()` to leverage pre-trained models for speech recognition. In [Unit 2](../chapter2/asr_pipeline),
 we introduced the `pipeline()` as an easy way of running speech recognition tasks, with all pre- and post-processing handled under-the-hood
 and the flexibility to quickly experiment with any pre-trained checkpoint on the Hugging Face Hub. In this Unit, we'll go a
 level deeper and explore the different attributes of speech recognition models and how we can use them to tackle a range
@@ -146,7 +146,7 @@ The remainder of this section will show you how to use the pre-trained Whisper m
 Transformers. In many situations, the pre-trained Whisper checkpoints are extremely performant and give great results,
 thus we encourage you to try using the pre-trained checkpoints as a first step to solving any speech recognition problem.
 Through fine-tuning, the pre-trained checkpoints can be adapted for specific datasets and languages to further improve
-upon these results. We'll demonstrate how to do this in the upcoming subsection on [fine-tuning](fine-tuning.mdx).
+upon these results. We'll demonstrate how to do this in the upcoming subsection on [fine-tuning](fine-tuning).
 
 The Whisper checkpoints come in five configurations of varying model sizes. The smallest four are trained on either
 English-only or multilingual data. The largest checkpoint is multilingual only. All nine of the pre-trained checkpoints

--- a/chapters/en/chapter5/demo.mdx
+++ b/chapters/en/chapter5/demo.mdx
@@ -1,10 +1,10 @@
 # Build a demo with Gradio
 
-Now that we've fine-tuned a Whisper model for Dhivehi speech recognition, let's go ahead and build a [Gradio]((https://gradio.app))
+Now that we've fine-tuned a Whisper model for Dhivehi speech recognition, let's go ahead and build a [Gradio](https://gradio.app)
 demo to showcase it to the community!
 
 The first thing to do is load up the fine-tuned checkpoint using the `pipeline()` class - this is very familiar now from 
-the section on [pre-trained models](asr_models.mdx). You can change the `model_id` to the namespace of your fine-tuned 
+the section on [pre-trained models](asr_models). You can change the `model_id` to the namespace of your fine-tuned 
 model on the Hugging Face Hub, or one of the pre-trained [Whisper models](https://huggingface.co/models?sort=downloads&search=openai%2Fwhisper-) 
 to perform zero-shot speech recognition:
 
@@ -19,7 +19,7 @@ Secondly, we'll define a function that takes the filepath for an audio input and
 the pipeline automatically takes care of loading the audio file, resampling it to the correct sampling rate, and running
 inference with the model. We can then simply return the transcribed text as the output of the function. To ensure our 
 model can handle audio inputs of arbitrary length, we'll enable *chunking* as described in the section 
-on [pre-trained models](asr_models.mdx):
+on [pre-trained models](asr_models):
 
 ```python
 def transcribe_speech(filepath):

--- a/chapters/en/chapter5/evaluation.mdx
+++ b/chapters/en/chapter5/evaluation.mdx
@@ -162,7 +162,7 @@ characters, or have to predict punctuation from the audio data alone (e.g. what 
 Because of this, the word error rates are naturally lower (meaning the results are better). The Whisper paper demonstrates
 the drastic effect that normalising transcriptions can have on WER results (*c.f.* Section 4.4 of the [Whisper paper](https://cdn.openai.com/papers/whisper.pdf)).
 While we get lower WERs, the model isn't necessarily better for production. The lack of casing and punctuation makes the predicted
-text from the model significantly harder to read. Take the example from the [previous section](asr_models.mdx), where we ran
+text from the model significantly harder to read. Take the example from the [previous section](asr_models), where we ran
 Wav2Vec2 and Whisper on the same audio sample from the LibriSpeech dataset. The Wav2Vec2 model predicts neither punctuation
 nor casing, whereas Whisper predicts both. Comparing the transcriptions side-by-side, we see that the Whisper transcription
 is far easier to read:

--- a/chapters/en/chapter5/fine-tuning.mdx
+++ b/chapters/en/chapter5/fine-tuning.mdx
@@ -41,7 +41,7 @@ Your token has been saved to /root/.huggingface/token
 
 ## Load Dataset
 
-[Common Voice 13]((https://huggingface.co/datasets/mozilla-foundation/common_voice_13_0)) contains approximately ten
+[Common Voice 13](https://huggingface.co/datasets/mozilla-foundation/common_voice_13_0) contains approximately ten
 hours of labelled Dhivehi data, three of which is held-out test data. This is extremely little data for fine-tuning, so
 we'll be relying on leveraging the extensive multilingual ASR knowledge acquired by Whisper during pre-training for the
 low-resource Dhivehi language.
@@ -333,7 +333,7 @@ Onwards!
 ### Evaluation Metrics
 
 Next, we define the evaluation metric we'll use on our evaluation set. We'll use the Word Error Rate (WER) metric introduced
-in the section on [Evaluation](evaluation.mdx), the 'de-facto' metric for assessing ASR systems.
+in the section on [Evaluation](evaluation), the 'de-facto' metric for assessing ASR systems.
 
 We'll load the WER metric from 🤗 Evaluate:
 
@@ -499,7 +499,7 @@ and fine-tuned it to recognise Dhivehi speech with adequate accuracy in under on
 The big question is how this compares to other ASR systems. For that, we can view the autoevaluate [leaderboard](https://huggingface.co/spaces/autoevaluate/leaderboards?dataset=mozilla-foundation%2Fcommon_voice_13_0&only_verified=0&task=automatic-speech-recognition&config=dv&split=test&metric=wer),
 a leaderboard that categorises models by language and dataset, and subsequently ranks them according to their WER.
 
-Looking at the leaderboard, we see that our model trained for 500 steps convincingly beats the pre-trained [Whisper Small](hf.co/openai/whisper-small)
+Looking at the leaderboard, we see that our model trained for 500 steps convincingly beats the pre-trained [Whisper Small](https://huggingface.co/openai/whisper-small)
 checkpoint that we evaluated in the previous section. Nice job 👏
 
 We see that there are a few checkpoints that do better than the one we trained. The beauty of the Hugging Face Hub is that
@@ -566,5 +566,5 @@ model to the Hugging Face Hub, and showcased how to share and use it with the `p
 
 If you followed through to this point, you should now have a fine-tuned checkpoint for speech recognition, well done! 🥳
 Even more importantly, you're equipped with all the tools you need to fine-tune the Whisper model on any speech recognition
-dataset or domain. So what are you waiting for! Pick one of the datasets covered in the section [Choosing a Dataset](choosing_dataset.mdx)
+dataset or domain. So what are you waiting for! Pick one of the datasets covered in the section [Choosing a Dataset](choosing_dataset)
 or select a dataset of your own, and see whether you can get state-of-the-art performance! The leaderboard is waiting for you...

--- a/chapters/en/chapter5/introduction.mdx
+++ b/chapters/en/chapter5/introduction.mdx
@@ -33,9 +33,9 @@ your model to your friends and family by building a live demo, one that takes an
 
 Specifically, we’ll cover:
 
-* [Pre-trained models for speech recognition](asr_models.mdx)
-* [Choosing a dataset](choosing_dataset.mdx)
-* [Evaluation and metrics for speech recognition](evaluation.mdx)
-* [How to fine-tune an ASR system with the Trainer API](fine-tuning.mdx)
-* [Building a demo](demo.mdx)
-* [Hands-on exercise](hands_on.mdx)
+* [Pre-trained models for speech recognition](asr_models)
+* [Choosing a dataset](choosing_dataset)
+* [Evaluation and metrics for speech recognition](evaluation)
+* [How to fine-tune an ASR system with the Trainer API](fine-tuning)
+* [Building a demo](demo)
+* [Hands-on exercise](hands_on)


### PR DESCRIPTION
All of the links in introduction.mdx seems to be broken -

![Screenshot from 2023-07-06 11-14-23](https://github.com/huggingface/audio-transformers-course/assets/56069179/5e002e09-7696-4d21-812d-3fc1d786cd45)

Removing the `.mdx` at the end seems to solve the issue(at least in the doc-builder).

![Screenshot from 2023-07-06 11-17-50](https://github.com/huggingface/audio-transformers-course/assets/56069179/88ec05d5-a3ef-492f-888a-8670158824a8)

