### PR TITLE
Update audio_classification_pipeline.mdx

### DIFF
--- a/chapters/en/chapter2/audio_classification_pipeline.mdx
+++ b/chapters/en/chapter2/audio_classification_pipeline.mdx
@@ -43,7 +43,7 @@ example = minds[0]
 ```
 
 If you recall the structure of the dataset, the raw audio data is stored in a NumPy array under `["audio"]["array"]`, let's
-pass is straight to the `classifier`:
+pass it straight to the `classifier`:
 
 ```py
 classifier(example["audio"]["array"])


### PR DESCRIPTION
Fixed a typo, "let's pass is straight to" --> "let's pass it straight to"