### PR TITLE
[U6] Pin VITS PR commit hash

### DIFF
--- a/chapters/en/chapter6/pre-trained_models.mdx
+++ b/chapters/en/chapter6/pre-trained_models.mdx
@@ -206,7 +206,7 @@ Once it's merged, you will have to install the library from source. Meanwhile, i
 example, you can install the model from the PR's branch:
 
 ```bash
-pip install git+https://github.com/hollance/transformers.git@vits
+pip install git+https://github.com/hollance/transformers.git@6900e8ba6532162a8613d2270ec2286c3f58f57b
 ```
 
 </Tip>


### PR DESCRIPTION
Fixes #90 by pinning the commit hash for pip installing the VITS branch. In doing so, the material in the course won't be affected by any updates to the PR.