### PR TITLE
Language code instructions updated in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ cd ~/path/to/audio-transformers-course
 cp -r chapters/en/CHAPTER-NUMBER chapters/LANG-ID/CHAPTER-NUMBER
 ```
 
-Here, `CHAPTER-NUMBER` refers to the chapter you'd like to work on and `LANG-ID` should be ISO 639-1 (two-letter) 
+Here, `CHAPTER-NUMBER` refers to the chapter you'd like to work on and `LANG-ID` should be ISO 639-1 (two lower case letters) 
 language code -- see [here](https://www.loc.gov/standards/iso639-2/php/code_list.php) for a handy table.
+Alternatively, {two lowercase letters}-{two uppercase letters} format is also supported, e.g. `zh-CN`, here's 
+an [example](https://huggingface.co/learn/nlp-course/zh-CN/chapter1/1).
 
 **✍️ Start translating**
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ cd ~/path/to/audio-transformers-course
 cp -r chapters/en/CHAPTER-NUMBER chapters/LANG-ID/CHAPTER-NUMBER
 ```
 
-Here, `CHAPTER-NUMBER` refers to the chapter you'd like to work on and `LANG-ID` should be one of the ISO 639-1 or ISO 639-2 
-language codes -- see [here](https://www.loc.gov/standards/iso639-2/php/code_list.php) for a handy table.
+Here, `CHAPTER-NUMBER` refers to the chapter you'd like to work on and `LANG-ID` should be ISO 639-1 (two-letter) 
+language code -- see [here](https://www.loc.gov/standards/iso639-2/php/code_list.php) for a handy table.
 
 **✍️ Start translating**
 


### PR DESCRIPTION
This readme update reflects that only two-letter language codes are supported for translations. 