### PR TITLE
Minor update to unit 4

### DIFF
--- a/chapters/en/chapter4/classification_models.mdx
+++ b/chapters/en/chapter4/classification_models.mdx
@@ -147,6 +147,7 @@ and verify this is correct:
 ```
 from IPython.display import Audio
 
+classifier(sample["audio"].copy())
 Audio(sample["audio"]["array"], rate=sample["audio"]["sampling_rate"])
 ```
 
@@ -289,7 +290,7 @@ take that as our prediction. Let's confirm whether we were right by listening to
 volume too high or else you might get a jump!):
 
 ```python
-Audio(audio, rate=16000)
+Audio(audio_sample, rate=16000)
 ```
 
 Perfect! We have the sound of a dog barking 🐕, which aligns with the model's prediction. Have a play with different audio

--- a/chapters/en/chapter4/fine-tuning.mdx
+++ b/chapters/en/chapter4/fine-tuning.mdx
@@ -40,7 +40,7 @@ GTZAN doesn't provide a predefined validation set, so we'll have to create one o
 genres, so we can use the `train_test_split()` method to quickly create a 90/10 split as follows:
 
 ```python
-gtzan = gtzan["train"].train_test_split(seed=42, shuffle=True, test_size=0.1)
+gtzan = gtzan.train_test_split(seed=42, shuffle=True, test_size=0.1)
 gtzan
 ```
 
@@ -109,6 +109,9 @@ This label looks correct, since it matches the filename of the audio file. Let's
 using Gradio to create a simple interface with the `Blocks` API:
 
 ```python
+import gradio as gr
+
+
 def generate_audio():
     example = gtzan["train"].shuffle()[0]
     audio = example["audio"]


### PR DESCRIPTION
When I try to run this demo directly, an error occurs, and the result shows that the 'array' field does not exist:
![03](https://github.com/huggingface/audio-transformers-course/assets/88936287/ec94f9ad-0431-4481-8eaa-d7922b7be744)

Try to solve this problem.
![02](https://github.com/huggingface/audio-transformers-course/assets/88936287/f5df0b6e-eaef-4278-9070-5c32311f983c)

The second problem can be caused by wrong variable name.
![04](https://github.com/huggingface/audio-transformers-course/assets/88936287/7b5ba57f-b62c-43de-af03-6429f850d6ec)

Change it to the correct variable name.
![05](https://github.com/huggingface/audio-transformers-course/assets/88936287/09ed6456-223b-4903-9283-909225da3075)

The third small problem is that GTZAN does not have a ['train'] field, so it can be deleted directly.

![01](https://github.com/huggingface/audio-transformers-course/assets/88936287/6599094c-0dd6-4eed-98ce-eb27a640791d)


Finally, gradio may need a package import operation.