### PR TITLE
fix: remove useless token

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,5 +16,4 @@ jobs:
       additional_args: --not_python_module
       languages: en bn ko es zh-CN ru fr tr
     secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
This token is not used by your action.
Secret is removed from the repository.