### PR TITLE
Chapter 7: Fix typo in voice-assistant.mdx

### DIFF
--- a/chapters/en/chapter7/voice-assistant.mdx
+++ b/chapters/en/chapter7/voice-assistant.mdx
@@ -261,7 +261,7 @@ def transcribe(chunk_length_s=5.0, stream_chunk_s=1.0):
         if not item["partial"][0]:
             break
 
-    return item["text"]
+        return item["text"]
 ```
 
 Let's give this a go and see how we get on! Once the microphone is live, start speaking and watch your transcription 


### PR DESCRIPTION
There was an issue with the indentation and `item["text"]` was not defined outside of the `for` loop using the wrong indentation.

<details><summary>Reproduction steps</summary>
<p>

Source: [Creating a voice assistant](https://huggingface.co/learn/audio-course/chapter7/voice-assistant#synthesise-speech)

```python
from transformers import pipeline

import torch

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

transcriber = pipeline(
    "automatic-speech-recognition", model="openai/whisper-base.en", device=device
)

import sys

from transformers.pipelines.audio_utils import ffmpeg_microphone_live


def transcribe(chunk_length_s=5.0, stream_chunk_s=1.0):
    sampling_rate = transcriber.feature_extractor.sampling_rate

    mic = ffmpeg_microphone_live(
        sampling_rate=sampling_rate,
        chunk_length_s=chunk_length_s,
        stream_chunk_s=stream_chunk_s,
    )

    print("Start speaking...")
    for item in transcriber(mic, generate_kwargs={"max_new_tokens": 128}):
        sys.stdout.write("\033[K")
        print(item["text"], end="\r")
        if not item["partial"][0]:
            break

    return item["text"]

transcribe()
```

</p>
</details> 

<details><summary>Error logs</summary>
<p>

```sh
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1334:(snd_func_refer) error evaluating name
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5701:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2664:(snd_pcm_open_noupdate) Unknown PCM default
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
Cell In[8], line 1
----> 1 transcribe()

Cell In[7], line 22, in transcribe(chunk_length_s, stream_chunk_s)
     19     if not item["partial"][0]:
     20         break
---> 22 return item["text"]

UnboundLocalError: cannot access local variable 'item' where it is not associated with a value
```

</p>
</details> 