### PR TITLE
Updated Gradio code from gr.outputs.Textbox() to gr.components.Textbox()

### DIFF
--- a/chapters/en/chapter5/demo.mdx
+++ b/chapters/en/chapter5/demo.mdx
@@ -47,13 +47,13 @@ demo = gr.Blocks()
 mic_transcribe = gr.Interface(
     fn=transcribe_speech,
     inputs=gr.Audio(sources="microphone", type="filepath"),
-    outputs=gr.outputs.Textbox(),
+    outputs=gr.components.Textbox(),
 )
 
 file_transcribe = gr.Interface(
     fn=transcribe_speech,
     inputs=gr.Audio(sources="upload", type="filepath"),
-    outputs=gr.outputs.Textbox(),
+    outputs=gr.components.Textbox(),
 )
 ```
 


### PR DESCRIPTION
Hello, I updated the deprecated code in the "Unit 5 - Building a demo with Gradio" section from -

```
import gradio as gr

demo = gr.Blocks()

mic_transcribe = gr.Interface(
    fn=transcribe_speech,
    inputs=gr.Audio(sources="microphone", type="filepath"),
    outputs=gr.outputs.Textbox(),
)

file_transcribe = gr.Interface(
    fn=transcribe_speech,
    inputs=gr.Audio(sources="upload", type="filepath"),
    outputs=gr.outputs.Textbox(),
)
```

To -

```
import gradio as gr

demo = gr.Blocks()

mic_transcribe = gr.Interface(
    fn=transcribe_speech,
    inputs=gr.Audio(sources="microphone", type="filepath"),
    outputs=gr.components.Textbox(),
)

file_transcribe = gr.Interface(
    fn=transcribe_speech,
    inputs=gr.Audio(sources="upload", type="filepath"),
    outputs=gr.components.Textbox(),
)
```