### PR TITLE
Remark on variance magnitude

### DIFF
--- a/chapters/en/chapter4/fine-tuning.mdx
+++ b/chapters/en/chapter4/fine-tuning.mdx
@@ -252,7 +252,7 @@ Mean: 0.000185, Variance: 0.0493
 ```
 
 We can see that the mean is close to zero already, but the variance is closer to 0.05. If the variance for the sample was
-larger, it could cause our model problems, since the dynamic range of the audio data would be very small and thus difficult to
+smaller, it could cause our model problems, since the dynamic range of the audio data would be very small and thus difficult to
 separate. Let's apply the feature extractor and see what the outputs look like:
 
 ```python


### PR DESCRIPTION
The variance is already less than 1, so making it even smaller would result in compressing the dynamic range even further. The next normalization step makes it larger, which a good thing.