### PR TITLE
Update fine-tuning.mdx

### DIFF
--- a/chapters/en/chapter4/fine-tuning.mdx
+++ b/chapters/en/chapter4/fine-tuning.mdx
@@ -440,7 +440,7 @@ num_train_epochs = 10
 
 training_args = TrainingArguments(
     f"{model_name}-finetuned-gtzan",
-    evaluation_strategy="epoch",
+    eval_strategy="epoch",
     save_strategy="epoch",
     learning_rate=5e-5,
     per_device_train_batch_size=batch_size,


### PR DESCRIPTION
The attribute evaluation_strategy is being deprecated in the Transformers repository (huggingface/transformers#30190). The evaluation_strategy usage in this repository should be replaced with the new eval_strategy.