### PR TITLE
Add plt.show() to actually show the plot

### DIFF
--- a/chapters/en/chapter1/load_and_explore.mdx
+++ b/chapters/en/chapter1/load_and_explore.mdx
@@ -148,6 +148,7 @@ sampling_rate = example["audio"]["sampling_rate"]
 
 plt.figure().set_figwidth(12)
 librosa.display.waveshow(array, sr=sampling_rate)
+plt.show()
 ```
 
 <div class="flex justify-center">


### PR DESCRIPTION
At least in my local environment, no plot appears unless I also add `plt.show()` as shown in this diff.