### PR TITLE
Fix typo in audio bit depth explanation

### DIFF
--- a/chapters/en/chapter1/audio_data.mdx
+++ b/chapters/en/chapter1/audio_data.mdx
@@ -62,7 +62,7 @@ The most common audio bit depths are 16-bit and 24-bit. Each is a binary term, r
 to which the amplitude value can be quantized when it's converted from continuous to discrete: 65,536 steps for 16-bit audio,
 a whopping 16,777,216 steps for 24-bit audio. Because quantizing involves rounding off the continuous value to a discrete
 value, the sampling process introduces noise. The higher the bit depth, the smaller this quantization noise. In practice,
-the quantization noise of 16-bit audio is already small enough to be audible, and using higher bit depths is generally
+the quantization noise of 16-bit audio is already small enough to be inaudible, and using higher bit depths is generally
 not necessary.
 
 You may also come across 32-bit audio. This stores the samples as floating-point values, whereas 16-bit and 24-bit audio


### PR DESCRIPTION
This PR corrects a wording error in the explanation of audio bit depth. The original text incorrectly stated that 16-bit quantization noise is “small enough to be audible,” which contradicts the intended meaning. It has been updated to “inaudible” to reflect that 16-bit quantization noise is typically imperceptible to the human ear.