### PR TITLE
Fix processor/tokenizer wording in course content

### DIFF
--- a/chapters/en/chapter1/preprocessing.mdx
+++ b/chapters/en/chapter1/preprocessing.mdx
@@ -216,7 +216,7 @@ many tasks involving audio are multimodal, e.g. speech recognition. In such case
 tokenizers to process the text inputs. For a deep dive into tokenizers, please refer to our [NLP course](https://huggingface.co/course/chapter2/4).
 
 You can load the feature extractor and tokenizer for Whisper and other multimodal models separately, or you can load both via
-a so-called processor. To make things even simpler, use `AutoProcessor` to load a model's feature extractor and processor from a
+a so-called processor. To make things even simpler, use `AutoProcessor` to load a model's feature extractor and tokenizer from a
 checkpoint, like this:
 
 ```py


### PR DESCRIPTION
## Summary
This PR fixes incorrect wording in the course content by replacing “processor” with “tokenizer” where the issue discussion identified that “tokenizer” is the correct term.

## Why this matters
Even though this is a small wording change, it can be confusing for learners following the course, especially in sections where the distinction between processor, feature extractor, and tokenizer matters.

## Changes made
- Replaced the incorrect term with the intended one
- Kept the change focused and minimal

Closes #195